### PR TITLE
Fix: link color

### DIFF
--- a/front/src/components/custom/LinkText.tsx
+++ b/front/src/components/custom/LinkText.tsx
@@ -8,7 +8,7 @@ export const LinkText = ({
   children: React.ReactNode;
 }) => {
   return (
-    <Link href={href} color="teal.300">
+    <Link href={href} color="cyan.600">
       {children}
     </Link>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
	- `Link` コンポーネントのテキストカラーを "teal.300" から "cyan.600" に変更しました。これにより、リンクの視覚的な表示が改善され、ユーザーインターフェースとユーザーエクスペリエンスに影響を与える可能性があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->