### PR TITLE
Feat: impl all

### DIFF
--- a/back/app/controllers/likes_controller.rb
+++ b/back/app/controllers/likes_controller.rb
@@ -18,4 +18,9 @@ class LikesController < ApplicationController
       render json: { message: 'Like not found' }, status: :not_found
     end
   end
+
+  def all
+    likes = Like.includes(:post, :user)
+    render json: likes.to_json(include: { user: { only: %i[id name] }, post: { only: %i[id content created_at] } })
+  end
 end

--- a/back/app/controllers/posts_controller.rb
+++ b/back/app/controllers/posts_controller.rb
@@ -49,6 +49,11 @@ class PostsController < ApplicationController
     render json: posts_serialize(posts)
   end
 
+  def all
+    posts = Post.includes(:user)
+    render json: posts.to_json(include: { user: { only: %i[id name] } })
+  end
+
   private
 
   def index_params

--- a/back/app/controllers/users_controller.rb
+++ b/back/app/controllers/users_controller.rb
@@ -12,4 +12,9 @@ class UsersController < ApplicationController
       render json: { message: 'User not found' }, status: :not_found
     end
   end
+
+  def all
+    users = User.all
+    render json: users.to_json(only: %i[id name created_at updated_at])
+  end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -12,13 +12,16 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   get    'users', to: 'users#index'
+  get    'users/all', to: 'users#all', as: 'all_user'
   get    'users/:id', to: 'users#show', as: 'show_user'
   get    'auth/sessions', to: 'sessions#sessions'
   post   'posts', to: 'posts#create', as: 'create_post'
   get    'posts', to: 'posts#index', as: 'index_post'
+  get    'posts/all', to: 'posts#all', as: 'all_post'
   get    'posts/ranking', to: 'posts#ranking', as: 'ranking_post'
   get    'posts/:id', to: 'posts#show', as: 'show_post'
   delete 'posts/:id', to: 'posts#destroy', as: 'destroy_post'
+  get    'likes/all', to: 'likes#all', as: 'all_like'
   post   'likes/:id', to: 'likes#create', as: 'create_like'
   delete 'likes/:id', to: 'likes#destroy', as: 'destroy_like'
 end


### PR DESCRIPTION
サービス終了に向け、User, Post, Like すべてを取得する API を実装


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザー、投稿、いいねの全件取得用エンドポイントを追加しました（/users/all、/posts/all、/likes/all）。
  - 各エンドポイントで関連情報を含んだJSON形式でデータを取得できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->